### PR TITLE
Feature/comment extension

### DIFF
--- a/config/backend.php
+++ b/config/backend.php
@@ -10,7 +10,8 @@ return [
     'controllerMap' => [
         'gallery' => 'extensions\gallery\controllers\GalleryController',
         'tag' => 'extensions\tag\controllers\TagController',
-        'notif' => 'extensions\notification\controllers\NotifController'
+        'notif' => 'extensions\notification\controllers\NotifController',
+        'comment' => 'extensions\comment\controllers\CommentController'
     ],
     'components' => [
         'view' => [

--- a/extensions/.gitignore
+++ b/extensions/.gitignore
@@ -5,4 +5,5 @@
 !mailer
 !tag
 !notification
+!comment
 !.gitignore

--- a/extensions/comment/actions/CommentAction.php
+++ b/extensions/comment/actions/CommentAction.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace extensions\comment\actions;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use yii\web\ServerErrorHttpException;
+use extensions\comment\models\Comment;
+
+class CommentAction extends \yii\base\Action
+{
+    public $moduleId;
+    public $ownerClassName;
+
+    public function init()
+    {
+        if (empty($this->moduleId)) {
+            throw new InvalidConfigException('moduleId property must be set.');
+        }
+        if (empty($this->ownerClassName)) {
+            throw new InvalidConfigException('ownerClassName property must be set.');
+        }
+        parent::init();
+    }
+
+    public function run($ownerId)
+    {
+        $comment = new Comment([
+            'moduleId' => $this->moduleId,
+            'ownerId' => $ownerId,
+            'ownerClassName' => (new \ReflectionClass($this->ownerClassName))
+                ->getShortName()
+        ]);
+        $comment->load(Yii::$app->getRequest()->getBodyParams(), '');
+        if ($comment->save()) {
+            Yii::$app->getResponse()
+                ->setStatusCode(201)
+                ->data = [
+                    'message' => 'نظر شما با موفقیت ثبت شد، پس از تایید در سایت نمایش داده خواهد شد.'
+                ];
+        } elseif ($comment->hasErrors()) {
+            Yii::$app->getResponse()
+                ->setStatusCode(422)
+                ->data = $comment->errors;
+        } else {
+            throw new ServerErrorHttpException('Failed to add comment for unknown reason.');
+        }
+    }
+}

--- a/extensions/comment/actions/IndexAction.php
+++ b/extensions/comment/actions/IndexAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace extensions\comment\actions;
+
+use Yii;
+use yii\base\InvalidConfigException;
+use extensions\comment\models\CommentSearch;
+
+class IndexAction extends \yii\base\Action
+{
+    public $moduleId;
+    public $ownerClassName;
+
+    public function init()
+    {
+        if (empty($this->moduleId)) {
+            throw new InvalidConfigException('moduleId property must be set.');
+        }
+        if (empty($this->ownerClassName)) {
+            throw new InvalidConfigException('ownerClassName property must be set.');
+        }
+        parent::init();
+    }
+
+    public function run()
+    {
+        $searchModel = new CommentSearch();
+        $params = Yii::$app->request->queryParams;
+        $params[$searchModel->formName()]['moduleId'] = $this->moduleId;
+        $params[$searchModel->formName()]['ownerClassName'] =
+            (new \ReflectionClass($this->ownerClassName))->getShortName();
+        return $this->controller->render('comment', [
+            'searchModel' => $searchModel,
+            'dataProvider' => $searchModel->search($params)
+        ]);
+    }
+}

--- a/extensions/comment/behaviors/CommentBehavior.php
+++ b/extensions/comment/behaviors/CommentBehavior.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace extensions\comment\behaviors;
+
+use Yii;
+use yii\db\ActiveRecord;
+use yii\base\InvalidConfigException;
+use extensions\comment\models\Comment;
+
+class CommentBehavior extends \yii\base\Behavior
+{
+    public $moduleId;
+
+    public function events()
+    {
+        return [
+            ActiveRecord::EVENT_AFTER_DELETE => 'deleteComments'
+        ];
+    }
+
+    public function init()
+    {
+        if (empty($this->moduleId)) {
+            throw new InvalidConfigException('moduleId property must be set.');
+        }
+        parent::init();
+    }
+
+    public function getAcceptedComments()
+    {
+        return Comment::find()
+            ->andWhere([
+                'moduleId' => $this->moduleId,
+                'ownerId' => $this->owner->id,
+                'ownerClassName' => (new \ReflectionClass($this->owner))
+                    ->getShortName(),
+                'status' => Comment::STATUS_ACCEPTED
+            ])
+            ->orderBy(['insertedAt' => SORT_DESC])
+            ->all();
+    }
+
+    public function deleteComments()
+    {
+        Yii::$app->db->createCommand()->delete('comment', [
+            'moduleId' => $this->moduleId,
+            'ownerId' => $this->owner->id,
+            'ownerClassName' => (new \ReflectionClass($this->owner))
+                ->getShortName()
+        ])->execute();
+    }
+}

--- a/extensions/comment/behaviors/NotificationBehavior.php
+++ b/extensions/comment/behaviors/NotificationBehavior.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace extensions\comment\behaviors;
+
+use extensions\comment\models\Comment;
+use extensions\comment\notifications\CommentInsertedNotification;
+
+class NotificationBehavior extends \yii\base\Behavior
+{
+    public function events()
+    {
+        return [
+            Comment::EVENT_COMMENT_INSERTED => 'commentInserted'
+        ];
+    }
+
+    public function commentInserted()
+    {
+        CommentInsertedNotification::create([
+            'moduleId' => $this->owner->moduleId,
+            'comment' => $this->owner,
+            'permissions' => ["{$this->owner->moduleId}.comment"]
+        ])->send();
+    }
+}

--- a/extensions/comment/controllers/CommentController.php
+++ b/extensions/comment/controllers/CommentController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace extensions\comment\controllers;
+
+use Yii;
+use yii\helpers\Json;
+use yii\web\Response;
+use yii\filters\VerbFilter;
+use yii\filters\AccessControl;
+use yii\filters\ContentNegotiator;
+use extensions\comment\models\Comment;
+use core\controllers\AjaxAdminController;
+use extensions\comment\models\CommentSearch;
+
+class CommentController extends AjaxAdminController
+{
+    public function init()
+    {
+        $this->modelClass = Comment::class;
+        $this->searchClass = CommentSearch::class;
+        parent::init();
+    }
+
+    public function behaviors()
+    {
+        return array_merge(
+            parent::behaviors(),
+            [
+                'access' => [
+                    'class' => AccessControl::class,
+                    'rules' => [
+                        [
+                            'allow' => true,
+                            'actions' => ['accept', 'reply', 'reject', 'delete'],
+                            'roles' => ['@']
+                        ],
+                        [
+                            'allow' => true,
+                            'actions' => ['captcha']
+                        ]
+                    ]
+                ],
+                'verbs' => [
+                    'class' => VerbFilter::class,
+                    'actions' => [
+                        'reply' => ['post']
+                    ]
+                ],
+                [
+                    'class' => ContentNegotiator::class,
+                    'only' => ['accept', 'reply', 'reject', 'delete'],
+                    'formats' => [
+                        'application/json' => Response::FORMAT_JSON
+                    ]
+                ]
+            ]
+        );
+    }
+
+    public function actionAccept($id)
+    {
+        $comment = $this->findModel($id);
+        $comment->status = Comment::STATUS_ACCEPTED;
+        $comment->save(false);
+        echo Json::encode([
+            'status' => 'success',
+            'message' => 'نظر مورد نظر با موفقیت تایید شد.'
+        ]);
+        exit;
+    }
+
+    public function actionReply($id)
+    {
+        $comment = $this->findModel($id);
+        if ($comment->load(Yii::$app->request->post())) {
+            $comment->repliedBy = Yii::$app->user->id;
+            $comment->repliedAt = time();
+            $comment->status = Comment::STATUS_ACCEPTED;
+            if ($comment->save(false)) {
+                echo Json::encode([
+                    'status' => 'success',
+                    'message' => 'پاسخ با موفقیت ثبت شد.'
+                ]);
+                exit;
+            }
+        }
+        echo Json::encode([
+            'status' => 'renderEmptyForm',
+            'content' => $this->renderAjax(
+                '@extensions/comment/views/reply.php',
+                [
+                    'comment' => $comment
+                ]
+            )
+        ]);
+        exit;
+    }
+
+    public function actionReject($id)
+    {
+        $comment = $this->findModel($id);
+        $comment->status = Comment::STATUS_REJECTED;
+        $comment->save(false);
+        echo Json::encode([
+            'status' => 'success',
+            'message' => 'نظر مورد نظر با موفقیت به وضعیت تایید نشده بروزرسانی شد.'
+        ]);
+        exit;
+    }
+}

--- a/extensions/comment/controllers/CommentController.php
+++ b/extensions/comment/controllers/CommentController.php
@@ -31,7 +31,13 @@ class CommentController extends AjaxAdminController
                     'rules' => [
                         [
                             'allow' => true,
-                            'actions' => ['accept', 'reply', 'reject', 'delete'],
+                            'actions' => [
+                                'view',
+                                'accept',
+                                'reply',
+                                'reject',
+                                'delete'
+                            ],
                             'roles' => ['@']
                         ],
                         [
@@ -48,13 +54,29 @@ class CommentController extends AjaxAdminController
                 ],
                 [
                     'class' => ContentNegotiator::class,
-                    'only' => ['accept', 'reply', 'reject', 'delete'],
+                    'only' => [
+                        'view',
+                        'accept',
+                        'reply',
+                        'reject',
+                        'delete'
+                    ],
                     'formats' => [
                         'application/json' => Response::FORMAT_JSON
                     ]
                 ]
             ]
         );
+    }
+
+    public function actionView($id)
+    {
+        echo Json::encode([
+            'content' => $this->renderAjax('@extensions/comment/views/view.php', [
+                'model' => $this->findModel($id)
+            ])
+        ]);
+        exit;
     }
 
     public function actionAccept($id)

--- a/extensions/comment/migrations/m180704_073705_create_comment_table.php
+++ b/extensions/comment/migrations/m180704_073705_create_comment_table.php
@@ -18,7 +18,7 @@ class m180704_073705_create_comment_table extends Migration
             'insertedBy' => $this->integer(),
             'inserterName' => $this->string(),
             'inserterEmail' => $this->string(),
-            'inserterIp' => $this->integer(),
+            'inserterIp' => $this->string(),
             'insertedAt' => $this->integer()->notNull(),
             'reply' => $this->text(),
             'repliedBy' => $this->integer(),

--- a/extensions/comment/migrations/m180704_073705_create_comment_table.php
+++ b/extensions/comment/migrations/m180704_073705_create_comment_table.php
@@ -1,0 +1,76 @@
+<?php
+
+use yii\db\Migration;
+
+class m180704_073705_create_comment_table extends Migration
+{
+    public function safeUp()
+    {
+        $tableOptions = null;
+        if ($this->db->driverName === 'mysql') {
+            $tableOptions =
+                'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+        }
+
+        $this->createTable('comment', [
+            'id' => $this->primaryKey(),
+            'content' => $this->text()->notNull(),
+            'insertedBy' => $this->integer(),
+            'inserterName' => $this->string(),
+            'inserterEmail' => $this->string(),
+            'inserterIp' => $this->integer(),
+            'insertedAt' => $this->integer()->notNull(),
+            'reply' => $this->text(),
+            'repliedBy' => $this->integer(),
+            'repliedAt' => $this->integer(),
+            'status' => $this->tinyInteger()->notNull()->defaultValue(1)
+                ->comment('1 => pending, 2 => reject, 3 => accept'),
+            'moduleId' => $this->string()->notNull(),
+            'ownerId' => $this->integer()->notNull(),
+            'ownerClassName' => $this->string()->notNull()
+        ], $tableOptions);
+
+        $this->createIndex(
+            'IDX_comment_moduleId',
+            'comment',
+            'moduleId'
+        );
+
+        $this->createIndex(
+            'IDX_comment_ownerId',
+            'comment',
+            'ownerId'
+        );
+
+        $this->createIndex(
+            'IDX_comment_ownerClassName',
+            'comment',
+            'ownerClassName'
+        );
+
+        $this->addForeignKey(
+            'FK_comment_user_insertedBy',
+            'comment',
+            'insertedBy',
+            'user',
+            'id',
+            'SET NULL',
+            'CASCADE'
+        );
+
+        $this->addForeignKey(
+            'FK_comment_user_repliedBy',
+            'comment',
+            'repliedBy',
+            'user',
+            'id',
+            'SET NULL',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('comment');
+    }
+}

--- a/extensions/comment/models/Comment.php
+++ b/extensions/comment/models/Comment.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace extensions\comment\models;
+
+use Yii;
+use core\behaviors\TimestampBehavior;
+use extensions\comment\behaviors\NotificationBehavior;
+use extensions\i18n\validators\FarsiCharactersValidator;
+
+class Comment extends \yii\db\ActiveRecord
+{
+    public $badge;
+    public $verifyCode;
+
+    const STATUS_PENDING = 1;
+    const STATUS_REJECTED = 2;
+    const STATUS_ACCEPTED = 3;
+    const EVENT_COMMENT_INSERTED = 'commentInserted';
+
+    public function behaviors()
+    {
+        return [
+            'Timestamp' => [
+                'class' => TimestampBehavior::class,
+                'createdAtAttribute' => 'insertedAt',
+                'updatedAtAttribute' => false
+            ],
+            'Notification' => [
+                'class' => NotificationBehavior::class
+            ]
+        ];
+    }
+
+    public function rules()
+    {
+        return [
+            ['content', 'required'],
+            ['status', 'integer'],
+            [
+                ['content', 'reply', 'inserterName', 'inserterEmail'],
+                'string'
+            ],
+            [['content', 'reply'], FarsiCharactersValidator::class],
+            [['inserterName', 'inserterEmail'], 'required', 'when' => function ($model) {
+                return $model->isNewRecord && !isset(Yii::$app->user->id);
+            }],
+            [['inserterName', 'inserterEmail'], 'trim'],
+            [['inserterName', 'inserterEmail'], 'default', 'value' => null],
+            ['inserterEmail', 'email'],
+            [
+                'verifyCode',
+                'captcha',
+                'captchaAction' => 'captcha/captcha',
+                'when' => function ($model) {
+                    return $model->isNewRecord && !isset(Yii::$app->user->id);
+                }
+            ]
+        ];
+    }
+
+    public function attributeLabels()
+    {
+        return [
+            'id' => 'شناسه',
+            'content' => 'نظر',
+            'insertedBy' => 'درج کننده',
+            'inserterName' => 'نام درج کننده',
+            'inserterEmail' => 'ایمیل درج کننده',
+            'inserterIp' => 'آی پی درج کننده',
+            'insertedAt' => 'تاریخ درج نظر',
+            'reply' => 'پاسخ',
+            'repliedBy' => 'پاسخ دهنده',
+            'repliedAt' => 'تاریخ درج پاسخ',
+            'status' => 'وضعیت',
+            'ownerId' => 'شناسه'
+        ];
+    }
+
+    public function beforeSave($insert)
+    {
+        if (!parent::beforeSave($insert)) {
+            return false;
+        }
+
+        if ($insert) {
+            $this->inserterIp = Yii::$app->request->userIP;
+            if (!Yii::$app->user->isGuest) {
+                $this->insertedBy = Yii::$app->user->id;
+            }
+        }
+        return true;
+    }
+
+    public function afterSave($insert, $changedAttributes)
+    {
+        if ($insert) {
+            $this->trigger(self::EVENT_COMMENT_INSERTED);
+        }
+        parent::afterSave($insert, $changedAttributes);
+    }
+
+    public function fields()
+    {
+        return [
+            'id',
+            'content',
+            'inserterName',
+            'inserterEmail',
+            'insertedAt',
+            'reply',
+            'repliedAt',
+            'badge'
+        ];
+    }
+
+    public static function tableName()
+    {
+        return 'comment';
+    }
+
+    public static function getStatusLabels()
+    {
+        return [
+            self::STATUS_PENDING => 'درحال بررسی',
+            self::STATUS_REJECTED => 'تایید نشده',
+            self::STATUS_ACCEPTED => 'تایید شده'
+        ];
+    }
+
+    public static function getPendingCommentsCount($moduleId, $ownerClassName)
+    {
+        return self::find()
+            ->andWhere([
+                'status' => self::STATUS_PENDING,
+                'moduleId' => $moduleId,
+                'ownerClassName' => (new \ReflectionClass($ownerClassName))
+                    ->getShortName()
+            ])
+        ->count();
+    }
+}

--- a/extensions/comment/models/CommentSearch.php
+++ b/extensions/comment/models/CommentSearch.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace extensions\comment\models;
+
+use yii\data\ActiveDataProvider;
+
+class CommentSearch extends Comment
+{
+    public $inserterMobile;
+
+    public function rules()
+    {
+        return [
+            [['insertedBy', 'status', 'ownerId'], 'integer'],
+            [
+                [
+                    'inserterName',
+                    'inserterEmail',
+                    'inserterIp',
+                    'moduleId',
+                    'ownerClassName',
+                    'content',
+                    'reply',
+                    'inserterMobile'
+                ],
+                'safe'
+            ]
+        ];
+    }
+
+    public function search($params)
+    {
+        $query = Comment::find();
+        $dataProvider = new ActiveDataProvider([
+            'query' => $query,
+            'sort' => [
+                'attributes' => [
+                    'ownerId',
+                    'insertedAt',
+                    'repliedAt',
+                    'status'
+                ],
+                'defaultOrder' => [
+                    'insertedAt' => SORT_DESC
+                ]
+            ]
+        ]);
+
+        $this->load($params);
+        if (!$this->validate()) {
+            $query->where('0=1');
+            return $dataProvider;
+        }
+
+        $query->andFilterWhere([
+            'comment.status' => $this->status,
+            'comment.ownerId' => $this->ownerId
+        ]);
+        $query->andFilterWhere(['like', 'comment.inserterName', $this->inserterName])
+            ->andFilterWhere(['like', 'comment.inserterEmail', $this->inserterEmail])
+            ->andFilterWhere(['like', 'comment.inserterIp', $this->inserterIp])
+            ->andFilterWhere(['like', 'comment.content', $this->content])
+            ->andFilterWhere(['like', 'comment.reply', $this->reply])
+            ->andFilterWhere(['comment.moduleId' => $this->moduleId])
+            ->andFilterWhere(['comment.ownerClassName' => $this->ownerClassName]);
+
+        if (!empty($this->inserterMobile)) {
+            $query->innerJoin('user', 'user.id = comment.insertedBy')
+                ->andWhere(['like', 'user.mobile', $this->inserterMobile]);
+        }
+
+        return $dataProvider;
+    }
+}

--- a/extensions/comment/notifications/CommentInsertedNotification.php
+++ b/extensions/comment/notifications/CommentInsertedNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace extensions\comment\notifications;
+
+use extensions\notification\Notification;
+
+class CommentInsertedNotification extends Notification
+{
+    public $comment;
+
+    public function getChannels()
+    {
+        return ['screen'];
+    }
+
+    public function getTitle()
+    {
+        return "نظر جدیدی برای {$this->getOwnerTitle()} ثبت شد.";
+    }
+
+    public function getRoute()
+    {
+        return [
+            "/{$this->comment->moduleId}/manage/comment",
+            'CommentSearch[ownerId]' => $this->comment->ownerId
+        ];
+    }
+
+    private function getOwnerTitle()
+    {
+        $ownerClassName = "modules\\{$this->comment->moduleId}\\common\\models\\{$this->comment->ownerClassName}";
+        return $ownerClassName::findOne($this->comment->ownerId)->title;
+    }
+}

--- a/extensions/comment/views/grid.php
+++ b/extensions/comment/views/grid.php
@@ -9,108 +9,119 @@ use extensions\comment\models\Comment;
 
 ?>
 
+<a class="ajaxcreate" data-gridpjaxid="comment-index-gridviewpjax"></a>
 <div class="comment-index">
-    <div class="sliding-form-wrapper"></div>
-        <?php Pjax::begin([
-            'id' => 'comment-index-gridviewpjax',
-            'enablePushState' => false
-        ]) ?>
-            <?= GridView::widget([
-                'dataProvider' => $dataProvider,
-                'filterModel' => $searchModel,
-                'options' => [
-                    'style' => 'overflow: auto; word-wrap: break-word'
-                ],
-                'columns' => [
-                    ['class' => 'yii\grid\SerialColumn'],
-                    [
-                        'label' => 'شناسه ' . $ownerPersianName,
-                        'attribute' => 'ownerId'
-                    ],
-                    [
-                        'label' => $ownerPersianName,
-                        'format' => 'raw',
-                        'value' => function ($model) use ($ownerClassName) {
+    <?php Pjax::begin([
+        'id' => 'comment-index-gridviewpjax',
+        'enablePushState' => false
+    ]) ?>
+    <?= GridView::widget([
+        'dataProvider' => $dataProvider,
+        'filterModel' => $searchModel,
+        'options' => [
+            'style' => 'overflow: auto; word-wrap: break-word'
+        ],
+        'columns' => [
+            ['class' => 'yii\grid\SerialColumn'],
+            [
+                'label' => 'شناسه ' . $ownerPersianName,
+                'attribute' => 'ownerId'
+            ],
+            [
+                'label' => $ownerPersianName,
+                'format' => 'raw',
+                'value' => function ($model) use ($ownerClassName) {
+                    return Html::a(
+                        $ownerClassName::findOne($model->ownerId)->title,
+                        ['view', 'id' => $model->ownerId],
+                        [
+                            'target' => '_blank',
+                            'data-pjax' => '0'
+                        ]
+                    );
+                }
+            ],
+            [
+                'attribute' => 'content',
+                'value' => function ($model) {
+                    return Utility::makeStringShorten($model->content);
+                },
+                'format' => 'raw',
+            ],
+            'inserterName',
+            'inserterEmail',
+            [
+                'label' => 'موبایل درج کننده',
+                'attribute' => 'inserterMobile',
+                'format' => 'farsiNumber',
+                'value' => function ($model) {
+                    if ($model->insertedBy) {
+                        return User::findOne($model->insertedBy)->mobile;
+                    }
+                }
+            ],
+            'insertedAt:datetime',
+            'reply:html',
+            [
+                'attribute' => 'status',
+                'filter' => Comment::getStatusLabels(),
+                'value' => function ($model) {
+                    return Comment::getStatusLabels()[$model->status];
+                }
+            ],
+            [
+                'class' => 'core\grid\AjaxActionColumn',
+                'template' => '{view} {reply} {accept} {delete} {reject}',
+                'buttons' => [
+                    'view' => function ($url, $model, $key) {
+                        return Html::a(
+                            '<span class="glyphicon glyphicon-eye-open"></span>',
+                            ['/comment/view', 'id' => $model->id],
+                            [
+                                'title' => 'مشاهده اطلاعات نظر',
+                                'class' => 'ajaxview',
+                                'data-gridpjaxid' => 'comment-index-gridviewpjax'
+                            ]
+                        );
+                    },
+                    'reply' => function ($url, $model, $key) {
+                        return Html::a(
+                            '<span class="fa fa-reply"></span>',
+                            ['/comment/reply', 'id' => $model->id],
+                            [
+                                'title' => 'پاسخ به نظر',
+                                'class' => 'ajaxupdate',
+                                'data-gridpjaxid' => 'comment-index-gridviewpjax'
+                            ]
+                        );
+                    },
+                    'accept' => function ($url, $model, $key) {
+                        if ($model->status != Comment::STATUS_ACCEPTED) {
                             return Html::a(
-                                $ownerClassName::findOne($model->ownerId)->title,
-                                ['view', 'id' => $model->ownerId],
+                                '<span class="fa fa-check"></span>',
+                                ['/comment/accept', 'id' => $model->id],
                                 [
-                                    'target' => '_blank',
-                                    'data-pjax' => '0'
+                                    'title' => 'تایید نظر',
+                                    'class' => 'ajaxrequest'
                                 ]
                             );
                         }
-                    ],
-                    [
-                        'attribute' => 'content',
-                        'value' => function ($model) {
-                            return Utility::makeStringShorten($model->content);
+                    },
+                    'reject' => function ($url, $model, $key) {
+                        if ($model->status != Comment::STATUS_REJECTED) {
+                            return Html::a(
+                                '<span class="glyphicon glyphicon-remove"></span>',
+                                ['/comment/reject', 'id' => $model->id],
+                                [
+                                    'title' => 'عدم تایید نظر',
+                                    'class' => 'ajaxrequest'
+                                ]
+                            );
                         }
-                    ],
-                    'inserterName',
-                    'inserterEmail',
-                    [
-                        'label' => 'موبایل درج کننده',
-                        'attribute' => 'inserterMobile',
-                        'format' => 'farsiNumber',
-                        'value' => function ($model) {
-                            if ($model->insertedBy) {
-                                return User::findOne($model->insertedBy)->mobile;
-                            }
-                        }
-                    ],
-                    'insertedAt:datetime',
-                    'reply:html',
-                    [
-                        'attribute' => 'status',
-                        'filter' => Comment::getStatusLabels(),
-                        'value' => function ($model) {
-                            return Comment::getStatusLabels()[$model->status];
-                        }
-                    ],
-                    [
-                        'class' => 'core\grid\AjaxActionColumn',
-                        'template' => '{reply} {accept} {delete} {reject}',
-                        'buttons' => [
-                            'reply' => function ($url, $model, $key) {
-                                return Html::a(
-                                    '<span class="fa fa-reply"></span>',
-                                    ['/comment/reply', 'id' => $model->id],
-                                    [
-                                        'title' => 'پاسخ به نظر',
-                                        'class' => 'ajaxupdate',
-                                        'data-pjaxid' => 'comment-index-gridviewpjax'
-                                    ]
-                                );
-                            },
-                            'accept' => function ($url, $model, $key) {
-                                if ($model->status != Comment::STATUS_ACCEPTED) {
-                                    return Html::a(
-                                        '<span class="fa fa-check"></span>',
-                                        ['/comment/accept', 'id' => $model->id],
-                                        [
-                                            'title' => 'تایید نظر',
-                                            'class' => 'ajaxrequest'
-                                        ]
-                                    );
-                                }
-                            },
-                            'reject' => function ($url, $model, $key) {
-                                if ($model->status != Comment::STATUS_REJECTED) {
-                                    return Html::a(
-                                        '<span class="glyphicon glyphicon-remove"></span>',
-                                        ['/comment/reject', 'id' => $model->id],
-                                        [
-                                            'title' => 'عدم تایید نظر',
-                                            'class' => 'ajaxrequest'
-                                        ]
-                                    );
-                                }
-                            }
-                        ]
-                    ]
+                    }
                 ]
-            ]) ?>
-        <?php Pjax::end() ?>
-    </div>
+            ]
+        ]
+    ]) ?>
+    <?php Pjax::end() ?>
 </div>

--- a/extensions/comment/views/grid.php
+++ b/extensions/comment/views/grid.php
@@ -1,0 +1,116 @@
+<?php
+
+use yii\helpers\Html;
+use yii\widgets\Pjax;
+use yii\grid\GridView;
+use core\helpers\Utility;
+use modules\user\common\models\User;
+use extensions\comment\models\Comment;
+
+?>
+
+<div class="comment-index">
+    <div class="sliding-form-wrapper"></div>
+        <?php Pjax::begin([
+            'id' => 'comment-index-gridviewpjax',
+            'enablePushState' => false
+        ]) ?>
+            <?= GridView::widget([
+                'dataProvider' => $dataProvider,
+                'filterModel' => $searchModel,
+                'options' => [
+                    'style' => 'overflow: auto; word-wrap: break-word'
+                ],
+                'columns' => [
+                    ['class' => 'yii\grid\SerialColumn'],
+                    [
+                        'label' => 'شناسه ' . $ownerPersianName,
+                        'attribute' => 'ownerId'
+                    ],
+                    [
+                        'label' => $ownerPersianName,
+                        'format' => 'raw',
+                        'value' => function ($model) use ($ownerClassName) {
+                            return Html::a(
+                                $ownerClassName::findOne($model->ownerId)->title,
+                                ['view', 'id' => $model->ownerId],
+                                [
+                                    'target' => '_blank',
+                                    'data-pjax' => '0'
+                                ]
+                            );
+                        }
+                    ],
+                    [
+                        'attribute' => 'content',
+                        'value' => function ($model) {
+                            return Utility::makeStringShorten($model->content);
+                        }
+                    ],
+                    'inserterName',
+                    'inserterEmail',
+                    [
+                        'label' => 'موبایل درج کننده',
+                        'attribute' => 'inserterMobile',
+                        'format' => 'farsiNumber',
+                        'value' => function ($model) {
+                            if ($model->insertedBy) {
+                                return User::findOne($model->insertedBy)->mobile;
+                            }
+                        }
+                    ],
+                    'insertedAt:datetime',
+                    'reply:html',
+                    [
+                        'attribute' => 'status',
+                        'filter' => Comment::getStatusLabels(),
+                        'value' => function ($model) {
+                            return Comment::getStatusLabels()[$model->status];
+                        }
+                    ],
+                    [
+                        'class' => 'core\grid\AjaxActionColumn',
+                        'template' => '{reply} {accept} {delete} {reject}',
+                        'buttons' => [
+                            'reply' => function ($url, $model, $key) {
+                                return Html::a(
+                                    '<span class="fa fa-reply"></span>',
+                                    ['/comment/reply', 'id' => $model->id],
+                                    [
+                                        'title' => 'پاسخ به نظر',
+                                        'class' => 'ajaxupdate',
+                                        'data-pjaxid' => 'comment-index-gridviewpjax'
+                                    ]
+                                );
+                            },
+                            'accept' => function ($url, $model, $key) {
+                                if ($model->status != Comment::STATUS_ACCEPTED) {
+                                    return Html::a(
+                                        '<span class="fa fa-check"></span>',
+                                        ['/comment/accept', 'id' => $model->id],
+                                        [
+                                            'title' => 'تایید نظر',
+                                            'class' => 'ajaxrequest'
+                                        ]
+                                    );
+                                }
+                            },
+                            'reject' => function ($url, $model, $key) {
+                                if ($model->status != Comment::STATUS_REJECTED) {
+                                    return Html::a(
+                                        '<span class="glyphicon glyphicon-remove"></span>',
+                                        ['/comment/reject', 'id' => $model->id],
+                                        [
+                                            'title' => 'عدم تایید نظر',
+                                            'class' => 'ajaxrequest'
+                                        ]
+                                    );
+                                }
+                            }
+                        ]
+                    ]
+                ]
+            ]) ?>
+        <?php Pjax::end() ?>
+    </div>
+</div>

--- a/extensions/comment/views/reply.php
+++ b/extensions/comment/views/reply.php
@@ -1,36 +1,42 @@
 <?php
 
 use yii\helpers\Html;
+use theme\widgets\Panel;
 use theme\widgets\Button;
 use yii\bootstrap\ActiveForm;
+use core\widgets\editor\Editor;
 
 ?>
 
-<div class="row">
-    <div class="col-md-8">
-        <div class="reply-comment-form">
-            <?php $form = ActiveForm::begin([
-                'options' => ['class' => 'sliding-form']
-            ]) ?>
-                <div class="well">
-                    <?= Html::encode($comment->content) ?>
-                </div>
-                <?= $form->field($comment, 'reply')->textarea() ?>
-                <?= Html::submitButton(
-                    '<i class="fa fa-save"></i> ذخیره',
-                    [
-                        'class' => 'btn btn-lg btn-success'
-                    ]
-                ) ?>
-                <?= Button::widget([
-                    'label' => 'انصراف',
-                    'options' => [
-                        'class' => 'btn-lg close-sliding-form-button'
-                    ],
-                    'type' => 'warning',
-                    'icon' => 'undo'
+<?php Panel::begin(['title' => 'پاسخ به نظر']) ?>
+    <div class="row">
+        <div class="col-md-8">
+            <div class="reply-comment-form">
+                <?php $form = ActiveForm::begin([
+                    'options' => ['class' => 'sliding-form']
                 ]) ?>
-            <?php ActiveForm::end() ?>
+                    <div class="well">
+                        <?= $comment->content ?>
+                    </div>
+                    <?= $form->field($comment, 'reply')->widget(
+                        Editor::class
+                    ) ?>
+                    <?= Html::submitButton(
+                        '<i class="fa fa-save"></i> ذخیره',
+                        [
+                            'class' => 'btn btn-lg btn-success'
+                        ]
+                    ) ?>
+                    <?= Button::widget([
+                        'label' => 'انصراف',
+                        'options' => [
+                            'class' => 'btn-lg close-sliding-form-button'
+                        ],
+                        'type' => 'warning',
+                        'icon' => 'undo'
+                    ]) ?>
+                <?php ActiveForm::end() ?>
+            </div>
         </div>
     </div>
-</div>
+<?php Panel::end() ?>

--- a/extensions/comment/views/reply.php
+++ b/extensions/comment/views/reply.php
@@ -1,0 +1,36 @@
+<?php
+
+use yii\helpers\Html;
+use theme\widgets\Button;
+use yii\bootstrap\ActiveForm;
+
+?>
+
+<div class="row">
+    <div class="col-md-8">
+        <div class="reply-comment-form">
+            <?php $form = ActiveForm::begin([
+                'options' => ['class' => 'sliding-form']
+            ]) ?>
+                <div class="well">
+                    <?= Html::encode($comment->content) ?>
+                </div>
+                <?= $form->field($comment, 'reply')->textarea() ?>
+                <?= Html::submitButton(
+                    '<i class="fa fa-save"></i> ذخیره',
+                    [
+                        'class' => 'btn btn-lg btn-success'
+                    ]
+                ) ?>
+                <?= Button::widget([
+                    'label' => 'انصراف',
+                    'options' => [
+                        'class' => 'btn-lg close-sliding-form-button'
+                    ],
+                    'type' => 'warning',
+                    'icon' => 'undo'
+                ]) ?>
+            <?php ActiveForm::end() ?>
+        </div>
+    </div>
+</div>

--- a/extensions/comment/views/view.php
+++ b/extensions/comment/views/view.php
@@ -1,0 +1,48 @@
+<?php
+
+use theme\widgets\Panel;
+use yii\widgets\DetailView;
+use modules\user\backend\models\User;
+use extensions\comment\models\Comment;
+
+?>
+
+<div class="post-category-view">
+    <div class="row">
+        <div class="col-md-5">
+            <?php Panel::begin([
+                'title' => 'اطلاعات نظر',
+                'showCloseButton' => true
+            ]) ?>
+                <?= DetailView::widget([
+                    'model' => $model,
+                    'attributes' => [
+                        'content:html',
+                        'inserterName',
+                        'inserterEmail',
+                        [
+                            'label' => 'موبایل درج کننده',
+                            'attribute' => 'inserterMobile',
+                            'format' => 'farsiNumber',
+                            'value' => function ($model) {
+                                if ($model->insertedBy) {
+                                    return User::findOne($model->insertedBy)->mobile;
+                                }
+                            }
+                        ],
+                        'inserterIp',
+                        'insertedAt:datetime',
+                        'reply:html',
+                        'repliedAt:datetime',
+                        [
+                            'attribute' => 'status',
+                            'value' => function ($model) {
+                                return Comment::getStatusLabels()[$model->status];
+                            }
+                        ]
+                    ]
+                ]) ?>
+            <?php Panel::end() ?>
+        </div>
+    </div>
+</div>

--- a/modules/post/backend/config.php
+++ b/modules/post/backend/config.php
@@ -20,6 +20,11 @@ return [
                 'url' => ['/post/category/index'],
                 'visible' => Yii::$app->user->canAccessAny(['post.categories'])
             ],
+            [
+                'label' => 'نظرات',
+                'url' => ['/post/manage/comment'],
+                'visible' => Yii::$app->user->canAccessAny(['post.comment'])
+            ],
         ]
     ]
 ];

--- a/modules/post/backend/controllers/ManageController.php
+++ b/modules/post/backend/controllers/ManageController.php
@@ -2,10 +2,10 @@
 
 namespace modules\post\backend\controllers;
 
-use Yii;
 use yii\filters\AccessControl;
-use modules\post\backend\models\Post;
 use core\controllers\AdminController;
+use modules\post\backend\models\Post;
+use extensions\comment\actions\IndexAction;
 use modules\post\backend\models\PostSearch;
 
 /**
@@ -38,7 +38,7 @@ class ManageController extends AdminController
                         ],
                         [
                             'allow' => true,
-                            'actions' => ['index', 'view', 'gallery'],
+                            'actions' => ['index', 'view', 'gallery', 'comment'],
                             'roles' => ['post.create', 'post.update', 'post.delete'],
                         ],
                     ],
@@ -53,6 +53,11 @@ class ManageController extends AdminController
             'gallery' => [
                 'class' => 'extensions\gallery\actions\GalleryAction',
                 'ownerModelClassName' => Post::className()
+            ],
+            'comment' => [
+                'class' => IndexAction::class,
+                'moduleId' => 'post',
+                'ownerClassName' => Post::class
             ]
         ];
     }

--- a/modules/post/backend/models/Post.php
+++ b/modules/post/backend/models/Post.php
@@ -5,6 +5,7 @@ namespace modules\post\backend\models;
 use modules\post\backend\models\PostQuery;
 use extensions\file\behaviors\FileBehavior;
 use extensions\tag\behaviors\TaggableBehavior;
+use extensions\comment\behaviors\CommentBehavior;
 use extensions\i18n\validators\FarsiCharactersValidator;
 
 class Post extends \yii\db\ActiveRecord
@@ -39,6 +40,10 @@ class Post extends \yii\db\ActiveRecord
             ],
             [
                 'class' => TaggableBehavior::class,
+                'moduleId' => 'post'
+            ],
+            'comment' => [
+                'class' => CommentBehavior::class,
                 'moduleId' => 'post'
             ]
         ];

--- a/modules/post/backend/views/manage/comment.php
+++ b/modules/post/backend/views/manage/comment.php
@@ -1,0 +1,22 @@
+<?php
+
+use theme\widgets\Panel;
+use modules\post\backend\models\Post;
+
+$this->title = 'مدیریت نظرات';
+$this->params['breadcrumbs'] = [
+    ['label' => 'نوشته ها', 'url' => ['index']],
+    $this->title
+];
+
+?>
+
+<div class="sliding-form-wrapper"></div>
+<?php Panel::begin(['title' => $this->title]) ?>
+    <?= $this->render('@extensions/comment/views/grid.php', [
+        'dataProvider' => $dataProvider,
+        'searchModel' => $searchModel,
+        'ownerPersianName' => 'نوشته',
+        'ownerClassName' => Post::class
+    ]) ?>
+<?php Panel::end() ?>


### PR DESCRIPTION
For using this extension you must do the following steps :

- For inserting comment use CommentAction stand alone action.

- If you want to show list of module's comments use IndexAction stand alone action and render helper view grid.php inside your own index view. you can also write it entirely.

- For managing comments use CommentController. you must declare /comment route to point to this controller. (maybe use controllerMap in your configuration)

- You must attach CommentBehavior to your model, this behavior listen to delete event for cascading deletion of attached comments and has some helper methods. 

- There is also another helper view to render reply form. its very naive so you can also write your own form.

- This extension also use publish notification on comment insertion in screen channel. the notification's permission is made by this convention "{moduleId}.comment" and has route by this convention "/{$this->comment->moduleId}/manage/comment".